### PR TITLE
Modify to prevent overwriting existing .env file

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ if (process.argv[2] === 'init') {
     }
 
     const LINE_ACCESS_TOKEN = process.argv[3];
-    fs.writeFile('.env', `LINE_ACCESS_TOKEN="${LINE_ACCESS_TOKEN}"`, (err) => {
+    fs.appendFile('.env', `LINE_ACCESS_TOKEN="${LINE_ACCESS_TOKEN}"`, (err) => {
       if (err) { throw err; }
     });
     console.log(`write ${LINE_ACCESS_TOKEN} in .env file`);


### PR DESCRIPTION
### Solved issue
`liff-cli init` overwrites  `.env` file when that exists and the environment variables which had been set already would be lost.

### What did cause the issue
`fs.writeFile` overwrites the existing file.

### Solution
replace `fs.writeFile()` to `fs.appendFile()`